### PR TITLE
Fix xauth error due to xlist

### DIFF
--- a/noah_dev.sh
+++ b/noah_dev.sh
@@ -56,15 +56,7 @@ run_image() {
         echo "${repo_dir}"
 
         XAUTH=/tmp/.docker.xauth
-        if [ ! -f $XAUTH ]; then
-            xauth_list=$(xauth nlist :0 | sed -e 's/^..../ffff/')
-            if [ ! -z "$xauth_list" ]; then
-                echo $xauth_list | xauth -f $XAUTH nmerge -
-            else
-                touch $XAUTH
-            fi
-            chmod a+r $XAUTH
-        fi
+        xauth nlist $DISPLAY | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -
 
         DOCKER_MOUNT_ARGS="\
         -v /tmp/.X11-unix:/tmp/.X11-unix:rw \


### PR DESCRIPTION
This PR introduces a small fix to the following error:

```
ffff 0012 646965676f2d323030342d6465736b746f70 0000 0012 4d49542d4d414749432d434f4f4b49452d31 0010 d868730e26e006729a727819508e6818 ffff 0012 646965676f2d323030342d6465736b746f70 0000 0012 4d49542d4d414749432d434f4f4b49452d31 0010 d868730e26e006729a727819508e6818
xauth:  file /tmp/.docker.xauth does not exist
xauth: (argv):1:  unable to read any entries from file "(stdin)"
```

Relevant fix was found here: https://github.com/lbeaucourt/Object-detection/issues/7#issuecomment-433085794